### PR TITLE
Update Trelby homepage

### DIFF
--- a/pkgs/by-name/tr/trelby/package.nix
+++ b/pkgs/by-name/tr/trelby/package.nix
@@ -51,7 +51,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = {
     description = "Free, multiplatform, feature-rich screenwriting program";
-    homepage = "www.trelby.org";
+    homepage = "htttps://www.trelby.org";
     downloadPage = "https://github.com/trelby/trelby";
     mainProgram = "trelby";
     license = lib.licenses.gpl2Only;


### PR DESCRIPTION
## Things done

Just added the full url for the trelby homepage. Currently the url doesn't generate a link properly on search.nix.org

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md